### PR TITLE
Setup initial filter logic bd

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -10,10 +10,8 @@ export const App = () => {
         <Route exact path="/">
           <Homepage />
         </Route>
-        <Route exact path="/results">
-          <Results />
-        </Route>
+        <Route exact path="/results/:skins" component={Results} />
       </header>
-    </div>
+    </div >
   );
 };

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -23,7 +23,7 @@ export const App = () => {
           <Homepage updateSelections={updateSelections} />
         </Route>
         <Route exact path="/results">
-          <Results />
+          <Results selectedSkins={selections} />
         </Route>
       </header>
     </div>

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -1,29 +1,17 @@
 import "./App.css";
 import {Homepage} from "../Homepage/Homepage";
 import {Results} from "../Results/Results";
-import React, {useState} from "react";
 import {Route} from "react-router-dom";
 
 export const App = () => {
-  const [selections, setSelections] = useState({
-    armor: false,
-    weapons: false,
-    dyes: false,
-  });
-  const updateSelections = (e) => {
-    let selectionsToUpdate = selections;
-    selectionsToUpdate[e.target.name] = !selectionsToUpdate[e.target.name];
-    setSelections(selectionsToUpdate);
-  };
-  console.log(process.env.REACT_APP_API_KEY)
   return (
     <div className="App">
       <header className="">
         <Route exact path="/">
-          <Homepage updateSelections={updateSelections} />
+          <Homepage />
         </Route>
         <Route exact path="/results">
-          <Results selectedSkins={selections} />
+          <Results />
         </Route>
       </header>
     </div>

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -15,6 +15,7 @@ export const App = () => {
     selectionsToUpdate[e.target.name] = !selectionsToUpdate[e.target.name];
     setSelections(selectionsToUpdate);
   };
+  console.log(process.env.REACT_APP_API_KEY)
   return (
     <div className="App">
       <header className="">

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -10,7 +10,7 @@ export const App = () => {
         <Route exact path="/">
           <Homepage />
         </Route>
-        <Route exact path="/results/:skins" component={Results} />
+        <Route exact path="/results/:results" component={Results} />
       </header>
     </div >
   );

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -23,7 +23,7 @@ export const App = () => {
           <Homepage updateSelections={updateSelections} />
         </Route>
         <Route exact path="/results">
-          <Results selectedSkins={selections} />
+          <Results />
         </Route>
       </header>
     </div>

--- a/src/Components/Homepage/Homepage.js
+++ b/src/Components/Homepage/Homepage.js
@@ -15,7 +15,7 @@ export const Homepage = (props) => {
   };
   const determineStateToPost = () => {
     const choices = Object.keys(selections)
-    const finalChoices = choices.map(selection => selections[selection] ? selection : null)
+    const finalChoices = choices.filter(selection => selections[selection])
     return `/results/${finalChoices}`;
   };
   const skinTypes = () => {

--- a/src/Components/Homepage/Homepage.js
+++ b/src/Components/Homepage/Homepage.js
@@ -14,7 +14,7 @@ export const Homepage = (props) => {
     setSelections(selectionsToUpdate);
   };
   const determineStateToPost = () => {
-    return `/results/:${Object.values(selections)}`;
+    return `/results/${Object.values(selections)}`;
   };
   const skinTypes = () => {
     let skins = ["armor", "weapons", "dyes"];

--- a/src/Components/Homepage/Homepage.js
+++ b/src/Components/Homepage/Homepage.js
@@ -1,7 +1,21 @@
 import "./Homepage.scss";
-import {Link} from 'react-router-dom'
+import {Link} from "react-router-dom";
+import React, {useState} from "react";
 
 export const Homepage = (props) => {
+  const [selections, setSelections] = useState({
+    armor: false,
+    weapons: false,
+    dyes: false,
+  });
+  const updateSelections = (e) => {
+    let selectionsToUpdate = selections;
+    selectionsToUpdate[e.target.name] = !selectionsToUpdate[e.target.name];
+    setSelections(selectionsToUpdate);
+  };
+  const determineStateToPost = () => {
+    return `/results/:${Object.values(selections)}`;
+  };
   const skinTypes = () => {
     let skins = ["armor", "weapons", "dyes"];
     return skins.map((skin, i) => {
@@ -11,11 +25,11 @@ export const Homepage = (props) => {
             key={i}
             type="checkbox"
             className={skin}
-            data-testid={`${skin}-test`}
+            data-testid={`${skin} -test`}
             name={skin}
-            onClick={(e) => props.updateSelections(e)}
+            onClick={updateSelections}
           ></input>
-          <label htmlFor="armor" className={`${skin}-label`}>
+          <label htmlFor="armor" className={`${skin} -label`}>
             {skin}
           </label>
         </div>
@@ -33,7 +47,9 @@ export const Homepage = (props) => {
               Which skins would you like to find?
             </h3>
             {skinTypes()}
-            <Link to='/results'><button className="skin-submit">Find skins!</button></Link>
+            <Link to={determineStateToPost}>
+              <button className="skin-submit">Find skins!</button>
+            </Link>
           </div>
         </main>
         <footer className="home-footer">Footer Content</footer>

--- a/src/Components/Homepage/Homepage.js
+++ b/src/Components/Homepage/Homepage.js
@@ -6,7 +6,7 @@ export const Homepage = (props) => {
   const [selections, setSelections] = useState({
     armor: false,
     weapons: false,
-    dyes: false,
+    back: false,
   });
   const updateSelections = (e) => {
     let selectionsToUpdate = selections;
@@ -14,10 +14,12 @@ export const Homepage = (props) => {
     setSelections(selectionsToUpdate);
   };
   const determineStateToPost = () => {
-    return `/results/${Object.values(selections)}`;
+    const choices = Object.keys(selections)
+    const finalChoices = choices.map(selection => selections[selection] ? selection : null)
+    return `/results/${finalChoices}`;
   };
   const skinTypes = () => {
-    let skins = ["armor", "weapons", "dyes"];
+    let skins = ["armor", "weapons", "back"];
     return skins.map((skin, i) => {
       return (
         <div className={skin}>

--- a/src/Components/Homepage/Homepage.js
+++ b/src/Components/Homepage/Homepage.js
@@ -4,9 +4,9 @@ import React, {useState} from "react";
 
 export const Homepage = (props) => {
   const [selections, setSelections] = useState({
-    armor: false,
-    weapons: false,
-    back: false,
+    Armor: false,
+    Weapons: false,
+    Back: false,
   });
   const updateSelections = (e) => {
     let selectionsToUpdate = selections;
@@ -19,7 +19,7 @@ export const Homepage = (props) => {
     return `/results/${finalChoices}`;
   };
   const skinTypes = () => {
-    let skins = ["armor", "weapons", "back"];
+    let skins = ["Armor", "Weapons", "Back"];
     return skins.map((skin, i) => {
       return (
         <div className={skin}>

--- a/src/Components/Homepage/Homepage.js
+++ b/src/Components/Homepage/Homepage.js
@@ -18,6 +18,7 @@ export const Homepage = (props) => {
     const finalChoices = choices.filter(selection => selections[selection])
     return `/results/${finalChoices}`;
   };
+
   const skinTypes = () => {
     let skins = ["Armor", "Weapons", "Back"];
     return skins.map((skin, i) => {

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -11,7 +11,6 @@ export const Results = (props) => {
   });
 
   useEffect(() => {
-    console.log(props.match.params);
     if (!mounted.current) {
       const getSkins = async () => {
         let neededSkins = await filterSkinsByType()
@@ -33,6 +32,7 @@ export const Results = (props) => {
   const filterSkinsByType = async (skins) => {
     const allNeededSkins = await getNeededSkins();
     let counter = Math.floor(allNeededSkins.length / 100);
+    console.log(counter)
     let i = 1;
     let start = 0;
     let end = 200;

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -1,5 +1,6 @@
 import "./Results.scss";
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
+import {getUserSkins, getAllSkins} from "../../apiCalls";
 
 export const Results = () => {
   const [neededSkins, setNeeededSkins] = useState({
@@ -7,12 +8,14 @@ export const Results = () => {
     weapons: [],
     dyes: [],
   })
+  const getNeededSkins = async () => {
+    const res = await getUserSkins()
+    console.log(res)
+  }
+  useEffect(() => {
+    getNeededSkins()
+  }, [])
 
-  const updateUserSkins = (e) => {
-    let selectionsToUpdate = selections;
-    selectionsToUpdate.userSkins =
-      setSelections(selectionsToUpdate);
-  };
   return (
     <div className="results">
       <header className='results-header'>

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -13,27 +13,39 @@ export const Results = (props) => {
   };
   const filterSkinsByType = async (skins) => {
     const allNeededSkins = await getNeededSkins();
-    //let counter = Math.floor(allNeededSkins.length / 200);
-    let counter = 3
+    let counter = Math.floor(allNeededSkins.length / 100);
     let i = 1;
-    let start = 0
+    let start = 0;
+    let end = 200;
     let stateHolder = {
-      armor: [],
-      weapons: [],
-      dyes: [],
+      Armor: [],
+      Weapon: [],
+      Back: [],
+      Gathering: []
     }
     while (i < counter) {
-      const joinedSkins = allNeededSkins.join(",").slice(start, 200);
+      const joinedSkins = allNeededSkins.join(",").slice(start, end);
       const skinsForUser = await getFilteredSkins(joinedSkins);
-      skinsForUser.forEach(skin => stateHolder[skin.type].push(skin))
+      skinsForUser.forEach(skin => {
+        if (props.match.params.results.includes(skin.type)) {
+          return stateHolder[skin.type].push(skin)
+        }
+        return
+      })
       i++
       start += 200
+      end += 200
     }
+    return stateHolder
   }
   useEffect(() => {
     console.log(props.match.params);
-    filterSkinsByType();
-  });
+    const getSkins = async () => {
+      let userSkins = await filterSkinsByType()
+      setNeeededSkins({userSkins})
+    }
+    getSkins()
+  }, []);
 
   return (
     <div className="results">

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -46,7 +46,7 @@ export const Results = (props) => {
       const joinedSkins = allNeededSkins.join(",").slice(start, end);
       const skinsForUser = await getFilteredSkins(joinedSkins);
       skinsForUser.forEach(skin => {
-        if (props.match.params.results.includes(skin.type)) {
+        if (props.match.params.results.includes(skin.type) && skin.name) {
           return stateHolder[skin.type].push(skin)
         }
         return
@@ -59,7 +59,10 @@ export const Results = (props) => {
   }
 
   const displaySkins = (skinType) => {
-    return neededSkins.neededSkins[skinType].map(skin => <li>{skin.name}</li>)
+    if (neededSkins.neededSkins) {
+      return neededSkins.neededSkins[skinType].map(skin => <li>{skin.name}</li>)
+    }
+    return <h3>Loading</h3>
   }
 
   return (
@@ -68,11 +71,17 @@ export const Results = (props) => {
         <h1>Skins you need to unlock!</h1>
       </header>
       <div className="left-sidebar">
-        <h3>right-side-for-armor</h3>
+        <h3>Armor</h3>
         <ul>{mounted.current && displaySkins("Armor")}</ul>
       </div>
-      <main className="results-main">right-side-for-weapons</main>
-      <div className="right-sidebar">right-side-for-dyes</div>
+      <main className="results-main">
+        <h3>Backpieces</h3>
+        <ul>{mounted.current && displaySkins("Back")}</ul>
+      </main>
+      <div className="right-sidebar">
+        <h3>Weapons</h3>
+        <ul>{mounted.current && displaySkins("Weapon")}</ul>
+      </div>
       <footer className="results-footer"></footer>
     </div>
   );

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -1,6 +1,6 @@
 import "./Results.scss";
 import React, {useState, useEffect} from "react";
-import {getUserSkins, getAllSkins} from "../../apiCalls";
+import {getUserSkins, getAllSkins, getFilteredSkins} from "../../apiCalls";
 
 export const Results = (props) => {
   const [neededSkins, setNeeededSkins] = useState({
@@ -11,20 +11,19 @@ export const Results = (props) => {
   const getNeededSkins = async () => {
     const userSkins = await getUserSkins()
     const allSkins = await getAllSkins()
-    let filteredSkins = allSkins.filter(skin => {
+    return allSkins.filter(skin => {
       return !userSkins.includes(skin)
     })
-    console.log(filteredSkins)
-    //const joined = res.join(',')
-    //filterSkinsByType(joined.slice(0, 100))
   }
   const filterSkinsByType = async (skins) => {
-    //const res = await getAllSkins(skins)
-    //console.log(res)
+    const allNeededSkins = await getNeededSkins()
+    const joinedSkins = allNeededSkins.join(',').slice(0, 500)
+    const skinsForUser = await getFilteredSkins(joinedSkins)
+    console.log(skinsForUser)
   }
   useEffect(() => {
     console.log(props.match.params)
-    getNeededSkins()
+    filterSkinsByType()
 
   })
 

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -13,10 +13,11 @@ export const Results = (props) => {
   };
   const filterSkinsByType = async (skins) => {
     const allNeededSkins = await getNeededSkins();
-    let counter = Math.floor(allNeededSkins.length / 200);
+    //let counter = Math.floor(allNeededSkins.length / 200);
+    let counter = 3
     let i = 1;
     let start = 0
-    stateHolder = {
+    let stateHolder = {
       armor: [],
       weapons: [],
       dyes: [],
@@ -24,9 +25,11 @@ export const Results = (props) => {
     while (i < counter) {
       const joinedSkins = allNeededSkins.join(",").slice(start, 200);
       const skinsForUser = await getFilteredSkins(joinedSkins);
-
+      skinsForUser.forEach(skin => stateHolder[skin.type].push(skin))
+      i++
+      start += 200
     }
-  };
+  }
   useEffect(() => {
     console.log(props.match.params);
     filterSkinsByType();

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -1,9 +1,27 @@
 import "./Results.scss";
-import React, {useState, useEffect} from "react";
+import React, {useState, useEffect, useRef} from "react";
 import {getUserSkins, getAllSkins, getFilteredSkins} from "../../apiCalls";
 
 export const Results = (props) => {
-  const [neededSkins, setNeeededSkins] = useState('{}');
+  const mounted = useRef()
+  const [neededSkins, setNeeededSkins] = useState({
+    Armor: [],
+    Weapon: [],
+    Back: []
+  });
+
+  useEffect(() => {
+    console.log(props.match.params);
+    if (!mounted.current) {
+      const getSkins = async () => {
+        let neededSkins = await filterSkinsByType()
+        setNeeededSkins({neededSkins})
+      }
+      getSkins()
+      mounted.current = true;
+    }
+  });
+
   const getNeededSkins = async () => {
     const userSkins = await getUserSkins();
     const allSkins = await getAllSkins();
@@ -11,6 +29,7 @@ export const Results = (props) => {
       return !userSkins.includes(skin);
     });
   };
+
   const filterSkinsByType = async (skins) => {
     const allNeededSkins = await getNeededSkins();
     let counter = Math.floor(allNeededSkins.length / 100);
@@ -38,21 +57,20 @@ export const Results = (props) => {
     }
     return stateHolder
   }
-  useEffect(() => {
-    console.log(props.match.params);
-    const getSkins = async () => {
-      let userSkins = await filterSkinsByType()
-      setNeeededSkins({userSkins})
-    }
-    getSkins()
-  }, []);
+
+  const displaySkins = (skinType) => {
+    return neededSkins.neededSkins[skinType].map(skin => <li>{skin.name}</li>)
+  }
 
   return (
     <div className="results">
       <header className="results-header">
         <h1>Skins you need to unlock!</h1>
       </header>
-      <div className="left-sidebar">right-side-for-armor</div>
+      <div className="left-sidebar">
+        <h3>right-side-for-armor</h3>
+        <ul>{mounted.current && displaySkins("Armor")}</ul>
+      </div>
       <main className="results-main">right-side-for-weapons</main>
       <div className="right-sidebar">right-side-for-dyes</div>
       <footer className="results-footer"></footer>

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -1,6 +1,18 @@
 import "./Results.scss";
+import React, {useState} from "react";
 
 export const Results = () => {
+  const [neededSkins, setNeeededSkins] = useState({
+    armor: [],
+    weapons: [],
+    dyes: [],
+  })
+
+  const updateUserSkins = (e) => {
+    let selectionsToUpdate = selections;
+    selectionsToUpdate.userSkins =
+      setSelections(selectionsToUpdate);
+  };
   return (
     <div className="results">
       <header className='results-header'>

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -2,19 +2,31 @@ import "./Results.scss";
 import React, {useState, useEffect} from "react";
 import {getUserSkins, getAllSkins} from "../../apiCalls";
 
-export const Results = () => {
+export const Results = (props) => {
   const [neededSkins, setNeeededSkins] = useState({
     armor: [],
     weapons: [],
     dyes: [],
   })
   const getNeededSkins = async () => {
-    const res = await getUserSkins()
-    console.log(res)
+    const userSkins = await getUserSkins()
+    const allSkins = await getAllSkins()
+    let filteredSkins = allSkins.filter(skin => {
+      return !userSkins.includes(skin)
+    })
+    console.log(filteredSkins)
+    //const joined = res.join(',')
+    //filterSkinsByType(joined.slice(0, 100))
+  }
+  const filterSkinsByType = async (skins) => {
+    //const res = await getAllSkins(skins)
+    //console.log(res)
   }
   useEffect(() => {
+    console.log(props.match.params)
     getNeededSkins()
-  }, [])
+
+  })
 
   return (
     <div className="results">

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -3,39 +3,44 @@ import React, {useState, useEffect} from "react";
 import {getUserSkins, getAllSkins, getFilteredSkins} from "../../apiCalls";
 
 export const Results = (props) => {
-  const [neededSkins, setNeeededSkins] = useState({
-    armor: [],
-    weapons: [],
-    dyes: [],
-  })
+  const [neededSkins, setNeeededSkins] = useState('{}');
   const getNeededSkins = async () => {
-    const userSkins = await getUserSkins()
-    const allSkins = await getAllSkins()
-    return allSkins.filter(skin => {
-      return !userSkins.includes(skin)
-    })
-  }
+    const userSkins = await getUserSkins();
+    const allSkins = await getAllSkins();
+    return allSkins.filter((skin) => {
+      return !userSkins.includes(skin);
+    });
+  };
   const filterSkinsByType = async (skins) => {
-    const allNeededSkins = await getNeededSkins()
-    const joinedSkins = allNeededSkins.join(',').slice(0, 500)
-    const skinsForUser = await getFilteredSkins(joinedSkins)
-    console.log(skinsForUser)
-  }
-  useEffect(() => {
-    console.log(props.match.params)
-    filterSkinsByType()
+    const allNeededSkins = await getNeededSkins();
+    let counter = Math.floor(allNeededSkins.length / 200);
+    let i = 1;
+    let start = 0
+    stateHolder = {
+      armor: [],
+      weapons: [],
+      dyes: [],
+    }
+    while (i < counter) {
+      const joinedSkins = allNeededSkins.join(",").slice(start, 200);
+      const skinsForUser = await getFilteredSkins(joinedSkins);
 
-  })
+    }
+  };
+  useEffect(() => {
+    console.log(props.match.params);
+    filterSkinsByType();
+  });
 
   return (
     <div className="results">
-      <header className='results-header'>
+      <header className="results-header">
         <h1>Skins you need to unlock!</h1>
       </header>
       <div className="left-sidebar">right-side-for-armor</div>
-      <main className='results-main'>right-side-for-weapons</main>
+      <main className="results-main">right-side-for-weapons</main>
       <div className="right-sidebar">right-side-for-dyes</div>
-      <footer className='results-footer'></footer>
+      <footer className="results-footer"></footer>
     </div>
   );
 };

--- a/src/Components/Results/Results.test.js
+++ b/src/Components/Results/Results.test.js
@@ -1,55 +1,50 @@
 import {Results} from "./Results";
 import {render, screen, waitFor} from "@testing-library/react";
+import {act} from 'react-dom/test-utils'
 import {MemoryRouter} from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import {getUserSkins, getAllSkins, getFilteredSkins} from "../../apiCalls.js";
 jest.mock("../../apiCalls.js");
+const filterSkinsByType = jest.fn()
 
-getUserSkins.mockResolvedValue([120, 121, 122, 123, 124, 129])
-getAllSkins.mockResolvedValue([120, 121, 122, 127, 128, 130])
-getFilteredSkins.mockResolvedValue([
-  {
-    "name": "Bifrost",
-    "type": "Weapon",
-    "id": 127,
-  },
-  {
-    "name": "Invisible Boots",
-    "type": "Armor",
-    "id": 128,
-  },
-  {
-    "name": "Ad-Infinium",
-    "type": "Back",
-    "id": 130,
-  }
-])
+
+beforeEach(() => {
+  getUserSkins.mockResolvedValue(new Array(200).fill().map((_, i) => (i)))
+  getAllSkins.mockResolvedValue(new Array(400).fill().map((_, i) => (i)))
+  getFilteredSkins.mockResolvedValue([
+    {
+      "name": "Bifrost",
+      "type": "Weapon",
+    },
+    {
+      "name": "Invisible Boots",
+      "type": "Armor",
+    },
+    {
+      "name": "Ad-Infinium",
+      "type": "Back",
+    }
+  ])
+})
+
 
 describe("Results", () => {
   it("Results page should render with headers", async () => {
-    render(
-      <MemoryRouter>
-        <Results match={{params: {results: "Armor,Weapons,Back"}}} />
-      </MemoryRouter>
-    );
+    act(() => {
+      render(<Results match={{params: {results: "Armor,Weapons,Back"}}} />)
+    });
     expect(screen.getByText(/Skins you need to unlock!/i)).toBeInTheDocument();
     expect(screen.getByText(/Armor/i)).toBeInTheDocument();
     expect(screen.getByText(/Backpieces/i)).toBeInTheDocument();
     expect(screen.getByText(/Weapons/i)).toBeInTheDocument();
-    screen.debug()
   });
 
   it("Should render with user selected skins after mount", async () => {
-    render(
-      <MemoryRouter>
-        <Results match={{params: {results: "Armor,Weapons,Back"}}} />
-      </MemoryRouter>
-    );
-    expect(screen.getByText(/Skins you need to unlock!/i)).toBeInTheDocument();
-    expect(screen.getByText(/Armor/i)).toBeInTheDocument();
-    expect(screen.getByText(/Backpieces/i)).toBeInTheDocument();
-    expect(screen.getByText(/Weapons/i)).toBeInTheDocument();
+    act(() => {
+      render(<Results match={{params: {results: "Armor,Weapons,Back"}}} />)
+    });
+    await waitFor(() => expect(screen.getByText(/Invisible Boots/i)).toBeInTheDocument())
     screen.debug()
   });
 });

--- a/src/Components/Results/Results.test.js
+++ b/src/Components/Results/Results.test.js
@@ -6,8 +6,6 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import {getUserSkins, getAllSkins, getFilteredSkins} from "../../apiCalls.js";
 jest.mock("../../apiCalls.js");
-const filterSkinsByType = jest.fn()
-
 
 beforeEach(() => {
   getUserSkins.mockResolvedValue(new Array(200).fill().map((_, i) => (i)))

--- a/src/Components/Results/Results.test.js
+++ b/src/Components/Results/Results.test.js
@@ -1,8 +1,55 @@
-import {render, screen} from '@testing-library/react';
-import {Results} from './Results';
+import {Results} from "./Results";
+import {render, screen, waitFor} from "@testing-library/react";
+import {MemoryRouter} from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import {getUserSkins, getAllSkins, getFilteredSkins} from "../../apiCalls.js";
+jest.mock("../../apiCalls.js");
 
-test('renders with Results', () => {
-  render(<Results />);
-  const linkElement = screen.getByText(/Skins you need to unlock!/i);
-  expect(linkElement).toBeInTheDocument();
+getUserSkins.mockResolvedValue([120, 121, 122, 123, 124, 129])
+getAllSkins.mockResolvedValue([120, 121, 122, 127, 128, 130])
+getFilteredSkins.mockResolvedValue([
+  {
+    "name": "Bifrost",
+    "type": "Weapon",
+    "id": 127,
+  },
+  {
+    "name": "Invisible Boots",
+    "type": "Armor",
+    "id": 128,
+  },
+  {
+    "name": "Ad-Infinium",
+    "type": "Back",
+    "id": 130,
+  }
+])
+
+describe("Results", () => {
+  it("Results page should render with headers", async () => {
+    render(
+      <MemoryRouter>
+        <Results match={{params: {results: "Armor,Weapons,Back"}}} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Skins you need to unlock!/i)).toBeInTheDocument();
+    expect(screen.getByText(/Armor/i)).toBeInTheDocument();
+    expect(screen.getByText(/Backpieces/i)).toBeInTheDocument();
+    expect(screen.getByText(/Weapons/i)).toBeInTheDocument();
+    screen.debug()
+  });
+
+  it("Should render with user selected skins after mount", async () => {
+    render(
+      <MemoryRouter>
+        <Results match={{params: {results: "Armor,Weapons,Back"}}} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Skins you need to unlock!/i)).toBeInTheDocument();
+    expect(screen.getByText(/Armor/i)).toBeInTheDocument();
+    expect(screen.getByText(/Backpieces/i)).toBeInTheDocument();
+    expect(screen.getByText(/Weapons/i)).toBeInTheDocument();
+    screen.debug()
+  });
 });

--- a/src/Components/Results/Results.test.js
+++ b/src/Components/Results/Results.test.js
@@ -48,6 +48,14 @@ describe("Results", () => {
     expect(screen.getByText(/Bifrost/i)).toBeInTheDocument()
     expect(screen.getByText(/Invisible Boots/i)).toBeInTheDocument()
     expect(screen.getByText(/Ad-Infinium/i)).toBeInTheDocument()
+  });
+
+  it("Should only load the selections the user has made", async () => {
+    act(() => {
+      render(<Results match={{params: {results: "Armor"}}} />)
+    });
+    await waitFor(() => expect(screen.getByText(/Invisible Boots/i)).toBeInTheDocument())
+    expect(screen.getByText(/Invisible Boots/i)).toBeInTheDocument()
     screen.debug()
   });
 

--- a/src/Components/Results/Results.test.js
+++ b/src/Components/Results/Results.test.js
@@ -44,7 +44,11 @@ describe("Results", () => {
     act(() => {
       render(<Results match={{params: {results: "Armor,Weapons,Back"}}} />)
     });
-    await waitFor(() => expect(screen.getByText(/Invisible Boots/i)).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText(/Bifrost/i)).toBeInTheDocument())
+    expect(screen.getByText(/Bifrost/i)).toBeInTheDocument()
+    expect(screen.getByText(/Invisible Boots/i)).toBeInTheDocument()
+    expect(screen.getByText(/Ad-Infinium/i)).toBeInTheDocument()
     screen.debug()
   });
+
 });

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,5 +1,5 @@
 export const getUserSkins = async () => {
-  const response = await fetch(process.env.API_KEY)
+  const response = await fetch(`https://api.guildwars2.com/v2/account/skins?access_token=${process.env.API_KEY}`)
   if (response.ok) {
     return await response.json()
   } else {

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,5 +1,5 @@
 export const getUserSkins = async () => {
-  const response = await fetch(`https://api.guildwars2.com/v2/account/skins?access_token=${process.env.API_KEY}`)
+  const response = await fetch(`https://api.guildwars2.com/v2/account/skins?access_token=${process.env.REACT_APP_API_KEY}`)
   if (response.ok) {
     return await response.json()
   } else {
@@ -7,11 +7,13 @@ export const getUserSkins = async () => {
   }
 }
 
-export const geAllSkins = async () => {
+export const getAllSkins = async () => {
   const response = await fetch('https://api.guildwars2.com/v1/skins.json')
   if (response.ok) {
+    console.log(response)
     return await response.json()
   } else {
     return response.error
   }
 }
+

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -8,9 +8,17 @@ export const getUserSkins = async () => {
 }
 
 export const getAllSkins = async () => {
-  const response = await fetch('https://api.guildwars2.com/v1/skins.json')
+  const response = await fetch(`https://api.guildwars2.com/v2/skins`)
   if (response.ok) {
-    console.log(response)
+    return await response.json()
+  } else {
+    return response.error
+  }
+}
+
+export const getFilteredSkins = async (skins) => {
+  const response = await fetch(`https://api.guildwars2.com/v2/skins?ids=${skins}`)
+  if (response.ok) {
     return await response.json()
   } else {
     return response.error


### PR DESCRIPTION
#### What's this PR do?  

- Moves all logic out of app in favor of it handling only the routing
- Adjust routing parameters to better be able to filter data based on user selections
- Add api call handler since api only allows 200 ids at a time
- Add `useEffect` `useRef` hooks to handle mounting/ updating logic
- Finalize filtering logic and display names of skins on results page
- Updates testing to be in-line with the stage of development

#### Where should the reviewer start? 

- Start by checking out the Results page

#### How should this be manually tested?  

- Run the app and go through some user stories
- Check that result categories change based on checkboxes selected
- Check that all skins appear correctly
- Check that all tests are passing

#### Any background context you want to provide?  

- The preview functional mock I had for the `HomePage` component now no longer works as it is a function inside of that functional component
- May have to cover this only through integration test "as seen currently in App" or look into enzyme given the time

#### What are the relevant tickets?  
closes #15 
closes #16 
closes #17 
closes #18 
closes #19 
closes #20 

#### Screenshots (if appropriate) 

![Uploading Screen Shot 2020-11-07 at 9.09.26 PM.png…]()

